### PR TITLE
feat: publish-tree script ipfs only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Only need for `publish-tree` script
+PINATA_JWT=
+SCRAPER_API_URL=
+SCRAPER_API_JWT=
+
+# Only needed for `set-root` script
+OWNER_PK=
+OWNER_MNEMONIC=

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 yarn-error.log
 /generated
 .env
+.env.*
+!.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 /node_modules
 yarn-error.log
 /generated
+.env

--- a/README.md
+++ b/README.md
@@ -32,12 +32,22 @@ Options:
 
 ### Publish Merkle Tree
 
+To publish a tree to IPFS and to the Scraper API, you need to set the respective env vars in an `.env` file.
+Use the example file as a template by running
+
+```bash
+cp .env.example .env
+```
+
+and set the respective values. Afterward you can run the script below.
+
 ```
 Usage: yarn publish-tree [options]
 
 Options:
-  -i, --input <path>  input JSON file location containing output of 'yarn create-tree'
-  -h, --help          display help for command
+  -i, --input <path>   input JSON file location containing output of 'yarn create-tree'
+  -ss, --skip-scraper  optional flag whether to skip scraper api upload (default: true)
+  -h, --help           display help for command
 ```
 
 ### Set Merkle Root / Window

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   },
   "dependencies": {
     "@across-protocol/sdk-v2": "^0.1.28",
+    "axios": "^1.1.2",
     "commander": "^9.4.1",
+    "dotenv": "^16.0.3",
     "ethers": "^5.7.1",
     "yup": "^1.0.0-beta.7"
   }

--- a/scripts/publish-tree.ts
+++ b/scripts/publish-tree.ts
@@ -71,7 +71,6 @@ async function main() {
       }
     }
   );
-  console.log(data);
 
   const outputFileName = inputFileName.replace(".json", "_published.json");
   const outputFilePath = writeToOutput(outputFileName, {
@@ -88,7 +87,7 @@ async function main() {
     const form = new FormData();
     form.append("file", fs.createReadStream(outputFilePath));
     const { scraperApiJwt, scraperApiUrl } = assertAndGetScraperEnvVars();
-    const { data } = await axios.post(
+    await axios.post(
       `${scraperApiUrl}/upload/merkle-distributor-recipients`,
       form,
       {
@@ -98,7 +97,6 @@ async function main() {
         }
       }
     );
-    console.log(data);
   }
 }
 

--- a/scripts/publish-tree.ts
+++ b/scripts/publish-tree.ts
@@ -1,17 +1,105 @@
 import { program } from "commander";
+import dotenv from "dotenv";
+import axios from "axios";
+import FormData from "form-data";
+import fs from "fs";
 
-// TODO
-// Get inspired from: https://github.com/UMAprotocol/protocol/blob/master/packages/merkle-distributor/scripts/2_PublishClaimsForWindow.ts
+import { parseInputFile, writeToOutput } from "../src/fs-utils";
+import {
+  assertAndGetPinataEnvVars,
+  assertAndGetScraperEnvVars,
+  checkRecipientAmountsAndDuplicates
+} from "../src/validation";
+import { treeFileSchema } from "../src/schemas";
+
+dotenv.config();
 
 program
   .requiredOption(
     "-i, --input <path>",
     "input JSON file location containing output of 'yarn create-tree'"
   )
+  .option(
+    "-ss, --skip-scraper",
+    "optional flag whether to skip scraper api upload",
+    true // TODO: set to false if Scraper API endpoint ready
+  )
   .parse(process.argv);
 
 async function main() {
-  console.log("TODO");
+  const options = program.opts();
+
+  console.log(`Publishing ${options.input} to IPFS and Scraper API...`);
+
+  const rawInputFile = parseInputFile(options.input);
+  const inputFile = {
+    ...rawInputFile,
+    // We transform this to an array because yup doesn't have good support for
+    // schemas with dynamic keys and type inference
+    recipientsWithProofs: Object.values(rawInputFile.recipientsWithProofs)
+  };
+  const inputFileName = options.input.split("/").at(-1) as string;
+
+  console.log("\n1. Validating input file...");
+  const validInputFile = treeFileSchema.validateSync(inputFile, {
+    abortEarly: false
+  });
+
+  console.log("\n2. Checking recipient amounts and duplicates...");
+  checkRecipientAmountsAndDuplicates(
+    validInputFile.recipientsWithProofs,
+    validInputFile.rewardsToDeposit
+  );
+
+  console.log("\n3. Store on IPFS...");
+  const { pinataJwt } = assertAndGetPinataEnvVars();
+  const { data } = await axios.post(
+    "https://api.pinata.cloud/pinning/pinJSONToIPFS",
+    {
+      pinataMetadata: {
+        name: inputFileName,
+        keyvalues: {
+          windowIndex: validInputFile.windowIndex
+        }
+      },
+      pinataContent: validInputFile
+    },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${pinataJwt}`
+      }
+    }
+  );
+  console.log(data);
+
+  const outputFileName = inputFileName.replace(".json", "_published.json");
+  const outputFilePath = writeToOutput(outputFileName, {
+    ipfsHash: data.IpfsHash,
+    ...rawInputFile
+  });
+  console.log(`\n4. Saved to ${outputFilePath}`);
+
+  console.log("\n5. Store on Scraper API...");
+  if (options.skipScraper) {
+    console.log("skipped");
+  } else {
+    // The Scraper API uses Multer which requires the file upload via `FormData`
+    const form = new FormData();
+    form.append("file", fs.createReadStream(outputFilePath));
+    const { scraperApiJwt, scraperApiUrl } = assertAndGetScraperEnvVars();
+    const { data } = await axios.post(
+      `${scraperApiUrl}/upload/merkle-distributor-recipients`,
+      form,
+      {
+        headers: {
+          Authorization: `Bearer ${scraperApiJwt}`,
+          ...form.getHeaders()
+        }
+      }
+    );
+    console.log(data);
+  }
 }
 
 main().catch((error) => {

--- a/scripts/publish-tree.ts
+++ b/scripts/publish-tree.ts
@@ -3,6 +3,7 @@ import dotenv from "dotenv";
 import axios from "axios";
 import FormData from "form-data";
 import fs from "fs";
+import path from "path";
 
 import { parseInputFile, writeToOutput } from "../src/fs-utils";
 import {
@@ -38,7 +39,7 @@ async function main() {
     // schemas with dynamic keys and type inference
     recipientsWithProofs: Object.values(rawInputFile.recipientsWithProofs)
   };
-  const inputFileName = options.input.split("/").at(-1) as string;
+  const inputFileName = path.basename(options.input, ".json");
 
   console.log("\n1. Validating input file...");
   const validInputFile = treeFileSchema.validateSync(inputFile, {
@@ -72,7 +73,7 @@ async function main() {
     }
   );
 
-  const outputFileName = inputFileName.replace(".json", "_published.json");
+  const outputFileName = `${inputFileName}_published.json`;
   const outputFilePath = writeToOutput(outputFileName, {
     ipfsHash: data.IpfsHash,
     ...rawInputFile

--- a/src/fs-utils.ts
+++ b/src/fs-utils.ts
@@ -1,0 +1,25 @@
+import fs from "fs";
+
+export function parseInputFile(inputFilePath: string) {
+  if (!fs.existsSync(inputFilePath)) {
+    throw new Error(`File ${inputFilePath} does not exist`);
+  }
+
+  return JSON.parse(fs.readFileSync(inputFilePath, { encoding: "utf8" }));
+}
+
+export function writeToOutput(
+  outputFileName: string,
+  outputFileContent: Record<string, any>
+) {
+  const outputDirPath = `${process.cwd()}/generated`;
+
+  if (!fs.existsSync(outputDirPath)) {
+    fs.mkdirSync(outputDirPath);
+  }
+
+  const outputFilePath = `${outputDirPath}/${outputFileName}`;
+  fs.writeFileSync(outputFilePath, JSON.stringify(outputFileContent, null, 2));
+
+  return outputFilePath;
+}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,10 +1,28 @@
 import { BigNumber, BigNumberish, utils } from "ethers";
 import { InferType } from "yup";
+import assert from "assert";
 
 import { recipientSchema } from "./schemas";
 
 type Recipient = InferType<typeof recipientSchema>;
 
+export function assertAndGetPinataEnvVars() {
+  assert(process.env.PINATA_JWT, "Env var PINATA_JWT missing");
+
+  return {
+    pinataJwt: process.env.PINATA_JWT
+  };
+}
+
+export function assertAndGetScraperEnvVars() {
+  assert(process.env.SCRAPER_API_URL, "Env var SCRAPER_API_URL missing");
+  assert(process.env.SCRAPER_API_JWT, "Env var SCRAPER_API_JWT missing");
+
+  return {
+    scraperApiUrl: process.env.SCRAPER_API_URL,
+    scraperApiJwt: process.env.SCRAPER_API_JWT
+  };
+}
 export function checkRecipientAmountsAndDuplicates(
   recipients: Recipient[],
   totalRewardsToDeposit: BigNumberish

--- a/yarn.lock
+++ b/yarn.lock
@@ -3473,6 +3473,15 @@ axios@^0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
+axios@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.1.2.tgz#8b6f6c540abf44ab98d9904e8daf55351ca4a331"
+  integrity sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -5563,6 +5572,11 @@ dot-case@^2.1.0:
   dependencies:
     no-case "^2.2.0"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 dotenv@^8.0.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
@@ -6838,7 +6852,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.12.1, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.9:
+follow-redirects@^1.12.1, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -11010,6 +11024,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This adds the publish-tree script. The script already contains the implementation to also upload to the Scraper API, but still needs to be fully tested when https://github.com/across-protocol/scraper-api/pull/93 is merged. The scope of this PR is therefore only the upload to IPFS via Pinata.